### PR TITLE
Fix error when logging back in, due to wrong name for Home screen.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ If you are using Expo Cli, clone the repo and run "expo start" in the root folde
 ```
 git clone https://github.com/instamobile/react-native-firebase.git
 cd react-native-firebase
+yarn
 expo start
 ```
 

--- a/src/screens/LoginScreen/LoginScreen.js
+++ b/src/screens/LoginScreen/LoginScreen.js
@@ -28,7 +28,7 @@ export default function LoginScreen({navigation}) {
                             return;
                         }
                         const user = firestoreDocument.data()
-                        navigation.navigate('Home', {user: user})
+                        navigation.navigate('HomeScreen', {user: user})
                     })
                     .catch(error => {
                         alert(error)


### PR DESCRIPTION
FIXES ERROR: The action 'NAVIGATE' with payload {"name":"Home","params":{"user":{"id":"F3GvkANFWcQc0xbrfE8EHr5qxDp2","fullName":"Chris1","email":"chris1@email.com"}}} was not handled by any navigator. - Do you have a screen named 'Home'?

Also added `Yarn` install to Expo instructions.